### PR TITLE
chg:usr:Add a config file. Modularize command line args

### DIFF
--- a/piicatcher/command_line.py
+++ b/piicatcher/command_line.py
@@ -1,79 +1,26 @@
 import argparse
-import json
-import tableprint
+import yaml
 
-from piicatcher.db.explorer import SqliteExplorer, MySQLExplorer, PostgreSQLExplorer
-from piicatcher.orm.models import init, Store
+from piicatcher.db.explorer import parser as explorer_parser
+from piicatcher.config import set_global_config
+from piicatcher.orm.models import init
 
 
 def get_parser(parser_cls=argparse.ArgumentParser):
     parser = parser_cls()
-    parser.add_argument("-s", "--host", required=True,
-                        help="Hostname of the database. File path if it is SQLite")
-    parser.add_argument("-R", "--port",
-                        help="Port of database.")
-    parser.add_argument("-u", "--user",
-                        help="Username to connect database")
-    parser.add_argument("-p", "--password",
-                        help="Password of the user")
+    parser.add_argument("-c", "--config-file", help="Path to config file")
 
-    parser.add_argument("-t", "--connection-type", default="sqlite",
-                        choices=["sqlite", "mysql", "postgres"],
-                        help="Type of database")
-
-    parser.add_argument("-c", "--scan-type", default='deep',
-                        choices=["deep", "shallow"],
-                        help="Choose deep(scan data) or shallow(scan column names only)")
-
-    parser.add_argument("-o", "--output", default=None,
-                        help="File path for report. If not specified, "
-                             "then report is printed to sys.stdout")
-    parser.add_argument("-f", "--output-format", choices=["ascii_table", "json", "orm"],
-                        default="ascii_table",
-                        help="Choose output format type")
-
-    parser.add_argument("--orm-host",
-                        help="Hostname of the MySQL database where output has to be stored.")
-    parser.add_argument("--orm-port",
-                        help="Port of the MySQL database where output has to be stored.")
-    parser.add_argument("--orm-user",
-                        help="Username of the MySQL database where output has to be stored.")
-    parser.add_argument("--orm-pass",
-                        help="Passport of the MySQL database where output has to be stored.")
+    sub_parsers = parser.add_subparsers()
+    explorer_parser(sub_parsers)
 
     return parser
 
 
 def dispatch(ns):
-    explorer = None
-    if ns.connection_type == "sqlite":
-        explorer = SqliteExplorer(ns.host)
-    elif ns.connection_type == "mysql":
-        explorer = MySQLExplorer(ns.host, ns.port, ns.user, ns.password)
-    elif ns.connection_type == "postgres":
-        explorer = PostgreSQLExplorer(ns.host, ns.port, ns.user, ns.password)
-
-    assert(explorer is not None)
-
-    if ns.scan_type is None or ns.scan_type == "deep":
-        explorer.scan()
-    else:
-        explorer.shallow_scan()
-
-    if ns.output_format == "ascii_table":
-        headers = ["schema", "table", "column", "has_pii"]
-        tableprint.table(explorer.get_tabular(), headers)
-    elif ns.output_format == "json":
-        print(json.dumps(explorer.get_dict(), sort_keys=True, indent=2))
-    elif ns.output_format == "orm":
-        ns_dict = vars(ns)
-        if 'orm_host' not in ns_dict \
-                or 'orm_port' not in ns_dict \
-                or 'orm_user' not in ns_dict \
-                or 'orm_pass' not in ns_dict:
-            raise RuntimeError("ORM Host, Port, User and Password are all required")
-        init(ns.orm_host, ns.orm_port, ns.orm_user, ns.orm_pass)
-        Store.save_schemas(explorer)
+    if ns.config_file is not None:
+        with open(ns.config_file, 'r') as stream:
+            set_global_config(yaml.load(stream))
+            init()
 
 
 def main():

--- a/piicatcher/config.py
+++ b/piicatcher/config.py
@@ -1,0 +1,6 @@
+config = {}
+
+
+def set_global_config(c):
+    global config    # Needed to modify global copy of config
+    config = c

--- a/piicatcher/db/explorer.py
+++ b/piicatcher/db/explorer.py
@@ -4,8 +4,65 @@ import sqlite3
 import pymysql
 import psycopg2
 import logging
+import json
+import tableprint
 
 from piicatcher.db.metadata import Schema, Table, Column
+from piicatcher.orm.models import Store
+
+
+def dispatch(ns):
+    explorer = None
+    if ns.connection_type == "sqlite":
+        explorer = SqliteExplorer(ns.host)
+    elif ns.connection_type == "mysql":
+        explorer = MySQLExplorer(ns.host, ns.port, ns.user, ns.password)
+    elif ns.connection_type == "postgres":
+        explorer = PostgreSQLExplorer(ns.host, ns.port, ns.user, ns.password)
+
+    assert (explorer is not None)
+
+    if ns.scan_type is None or ns.scan_type == "deep":
+        explorer.scan()
+    else:
+        explorer.shallow_scan()
+
+    if ns.output_format == "ascii_table":
+        headers = ["schema", "table", "column", "has_pii"]
+        tableprint.table(explorer.get_tabular(), headers)
+    elif ns.output_format == "json":
+        print(json.dumps(explorer.get_dict(), sort_keys=True, indent=2))
+    elif ns.output_format == "orm":
+        Store.save_schemas(explorer)
+
+
+def parser(sub_parsers):
+    sub_parser = sub_parsers.add_parser("db")
+
+    sub_parser.add_argument("-s", "--host", required=True,
+                            help="Hostname of the database. File path if it is SQLite")
+    sub_parser.add_argument("-R", "--port",
+                            help="Port of database.")
+    sub_parser.add_argument("-u", "--user",
+                            help="Username to connect database")
+    sub_parser.add_argument("-p", "--password",
+                            help="Password of the user")
+
+    sub_parser.add_argument("-t", "--connection-type", default="sqlite",
+                            choices=["sqlite", "mysql", "postgres"],
+                            help="Type of database")
+
+    sub_parser.add_argument("-c", "--scan-type", default='deep',
+                            choices=["deep", "shallow"],
+                            help="Choose deep(scan data) or shallow(scan column names only)")
+
+    sub_parser.add_argument("-o", "--output", default=None,
+                            help="File path for report. If not specified, "
+                                 "then report is printed to sys.stdout")
+    sub_parser.add_argument("-f", "--output-format", choices=["ascii_table", "json", "orm"],
+                            default="ascii_table",
+                            help="Choose output format type")
+    sub_parser.set_defaults(func=dispatch)
 
 
 class Explorer(ABC):

--- a/piicatcher/orm/models.py
+++ b/piicatcher/orm/models.py
@@ -3,6 +3,7 @@ import json
 from peewee import *
 
 from piicatcher.piitypes import PiiTypeEncoder
+from piicatcher.config import config
 
 database_proxy = DatabaseProxy()
 
@@ -30,15 +31,17 @@ class DbColumns(BaseModel):
     table_id = ForeignKeyField(DbTables, 'id')
 
 
-def init(host, port, user, password):
-    database = MySQLDatabase('tokern',
-                             host=host,
-                             port=int(port),
-                             user=user,
-                             password=password)
-    database_proxy.initialize(database)
-    database_proxy.connect()
-    database_proxy.create_tables([DbSchemas, DbTables, DbColumns])
+def init():
+    if 'orm' in config:
+        orm = config['orm']
+        database = MySQLDatabase('tokern',
+                                 host=orm['host'],
+                                 port=int(orm['port']),
+                                 user=orm['user'],
+                                 password=orm['password'])
+        database_proxy.initialize(database)
+        database_proxy.connect()
+        database_proxy.create_tables([DbSchemas, DbTables, DbColumns])
 
 
 def init_test(path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,6 @@ pymysql
 psycopg2-binary
 cryptography
 peewee
+pyyaml
 
 pytest

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1,7 +1,7 @@
-from unittest import TestCase, mock
-from piicatcher.command_line import get_parser, dispatch
+from unittest import TestCase
+from piicatcher.command_line import get_parser
 
-from argparse import ArgumentParser, Namespace
+from argparse import ArgumentParser
 
 
 class ErrorRaisingArgumentParser(ArgumentParser):
@@ -12,126 +12,37 @@ class ErrorRaisingArgumentParser(ArgumentParser):
 class TestParser(TestCase):
     def test_host_required(self):
         with self.assertRaises(ValueError):
-            get_parser(ErrorRaisingArgumentParser).parse_args([])
+            get_parser(ErrorRaisingArgumentParser).parse_args(["db"])
 
     def test_host(self):
-        ns = get_parser().parse_args(["-s", "connection_string"])
+        ns = get_parser().parse_args(["db", "-s", "connection_string"])
         self.assertEqual("connection_string", ns.host)
 
     def test_port(self):
-        ns = get_parser().parse_args(["-s", "connection_string", "-R", "6032"])
+        ns = get_parser().parse_args(["db", "-s", "connection_string", "-R", "6032"])
         self.assertEqual("connection_string", ns.host)
         self.assertEqual("6032", ns.port)
 
     def test_host_user_password(self):
-        ns = get_parser().parse_args(["-s", "connection_string", "-u", "user", "-p", "passwd"])
+        ns = get_parser().parse_args(["db", "-s", "connection_string", "-u", "user", "-p", "passwd"])
         self.assertEqual("connection_string", ns.host)
         self.assertEqual("user", ns.user)
         self.assertEqual("passwd", ns.password)
 
     def test_default_console(self):
-        ns = get_parser().parse_args(["-s", "connection_string"])
+        ns = get_parser().parse_args(["db", "-s", "connection_string"])
         self.assertIsNone(ns.output)
         self.assertEqual("ascii_table", ns.output_format)
 
     def test_default_scan_type(self):
-        ns = get_parser().parse_args(["-s", "connection_string"])
+        ns = get_parser().parse_args(["db", "-s", "connection_string"])
         self.assertIsNone(ns.scan_type)
 
     def test_deep_scan_type(self):
-        ns = get_parser().parse_args(["-s", "connection_string", "-c", "deep"])
+        ns = get_parser().parse_args(["db", "-s", "connection_string", "-c", "deep"])
         self.assertEqual("deep", ns.scan_type)
 
     def test_default_scan_type(self):
-        ns = get_parser().parse_args(["-s", "connection_string", "-c", "shallow"])
+        ns = get_parser().parse_args(["db", "-s", "connection_string", "-c", "shallow"])
         self.assertEqual("shallow", ns.scan_type)
-
-
-class TestDispatcher(TestCase):
-
-    def test_sqlite_dispatch(self):
-        with mock.patch('piicatcher.command_line.SqliteExplorer.scan', autospec=True) as mock_scan_method:
-            with mock.patch('piicatcher.command_line.SqliteExplorer.get_tabular', autospec=True) as mock_tabular_method:
-                with mock.patch('piicatcher.command_line.tableprint', autospec=True) as MockTablePrint:
-                    dispatch(Namespace(host='connection', output_format='ascii_table', connection_type='sqlite',
-                                       scan_type=None, port=None))
-                    mock_scan_method.assert_called_once()
-                    mock_tabular_method.assert_called_once()
-                    MockTablePrint.table.assert_called_once()
-
-    def test_mysql_dispatch(self):
-        with mock.patch('piicatcher.command_line.MySQLExplorer.scan', autospec=True) as mock_scan_method:
-            with mock.patch('piicatcher.command_line.MySQLExplorer.get_tabular', autospec=True) as mock_tabular_method:
-                with mock.patch('piicatcher.command_line.tableprint', autospec=True) as MockTablePrint:
-                    dispatch(Namespace(host='connection',
-                                       port=None,
-                                       output_format='ascii_table',
-                                       connection_type='mysql',
-                                       scan_type='deep',
-                                       user='user',
-                                       password='pass'))
-                    mock_scan_method.assert_called_once()
-                    mock_tabular_method.assert_called_once()
-                    MockTablePrint.table.assert_called_once()
-
-    def test_postgres_dispatch(self):
-        with mock.patch('piicatcher.command_line.PostgreSQLExplorer.scan', autospec=True) as mock_scan_method:
-            with mock.patch('piicatcher.command_line.PostgreSQLExplorer.get_tabular', autospec=True) as mock_tabular_method:
-                with mock.patch('piicatcher.command_line.tableprint', autospec=True) as MockTablePrint:
-                    dispatch(Namespace(host='connection',
-                                       port=None,
-                                       output_format='ascii_table',
-                                       connection_type='postgres',
-                                       scan_type=None,
-                                       user='user',
-                                       password='pass'))
-                    mock_scan_method.assert_called_once()
-                    mock_tabular_method.assert_called_once()
-                    MockTablePrint.table.assert_called_once()
-
-    def test_mysql_shallow_scan(self):
-        with mock.patch('piicatcher.command_line.MySQLExplorer.shallow_scan', autospec=True) as mock_shallow_scan_method:
-            with mock.patch('piicatcher.command_line.MySQLExplorer.get_tabular', autospec=True) as mock_tabular_method:
-                with mock.patch('piicatcher.command_line.tableprint', autospec=True) as MockTablePrint:
-                    dispatch(Namespace(host='connection',
-                                       port=None,
-                                       output_format='ascii_table',
-                                       connection_type='mysql',
-                                       user='user',
-                                       password='pass',
-                                       scan_type="shallow"))
-                    mock_shallow_scan_method.assert_called_once()
-                    mock_tabular_method.assert_called_once()
-                    MockTablePrint.table.assert_called_once()
-
-
-class TestOrmDispatch(TestCase):
-    def test_all_missing_parameters(self):
-        with mock.patch('piicatcher.command_line.MySQLExplorer.shallow_scan', autospec=True) as mock_shallow_scan_method:
-            self.assertRaises(RuntimeError, lambda: dispatch(Namespace(host='connection',
-                                                                       port=None,
-                                                                       output_format='orm',
-                                                                       connection_type='mysql',
-                                                                       user='user',
-                                                                       password='pass',
-                                                                       scan_type='shallow_scan')))
-
-    def test_positive_dispatch(self):
-        with mock.patch('piicatcher.command_line.MySQLExplorer.shallow_scan', autospec=True) as mock_shallow_scan_method:
-            with mock.patch('piicatcher.command_line.init', autospec=True) as mock_init_method:
-                with mock.patch('piicatcher.command_line.Store', autospec=True) as MockStore:
-                    dispatch(Namespace(host='connection',
-                                       port=None,
-                                       output_format='orm',
-                                       connection_type='mysql',
-                                       user='user',
-                                       password='pass',
-                                       scan_type="shallow",
-                                       orm_host='orm_host',
-                                       orm_port='orm_port',
-                                       orm_user='orm_user',
-                                       orm_pass='orm_pass'))
-                    mock_shallow_scan_method.assert_called_once()
-                    mock_init_method.assert_called_once()
-                    MockStore.save_schemas.assert_called_once()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,19 @@
+from unittest import TestCase
+import yaml
+
+config_file = """
+orm:
+  host: a_host
+  port: 3306
+  user: a_user
+  password: a_password
+"""
+
+
+class TestConfigFile(TestCase):
+    def testOrmConfig(self):
+        orm = yaml.load(config_file)['orm']
+        self.assertEqual("a_host", orm['host'])
+        self.assertEqual(3306, orm["port"])
+        self.assertEqual("a_user", orm['user'])
+        self.assertEqual("a_password", orm['password'])


### PR DESCRIPTION
Add support for a config file. Config file will contain options
for storing results in a database.

Modularize command line arguments and put database scan options in
a sub command. This change is done to support more functionality.